### PR TITLE
Fixes for #34

### DIFF
--- a/scanpy_recipes/config_template.ini
+++ b/scanpy_recipes/config_template.ini
@@ -1,4 +1,5 @@
 [names]
+pi_name = EXAMPLE_TEXT
 customer_name = EXAMPLE_TEXT
 analyst_name = EXAMPLE_TEXT
 analysis_name = EXAMPLE_TEXT
@@ -30,6 +31,22 @@ EXAMPLE_SAMPLE1 = EXAMPLE_DIR1
 EXAMPLE_SAMPLE2 = EXAMPLE_DIR2
 EXAMPLE_SAMPLE3 = EXAMPLE_DIR3
 
-[sample_info]
-target_cells = 6000
-10x_chemistry = v2
+[target_cells]
+EXAMPLE_SAMPLE1 = 6000
+EXAMPLE_SAMPLE2 = 3000
+EXAMPLE_SAMPLE3 = 4000
+
+[10x_chemistry]
+EXAMPLE_SAMPLE1 = v2
+EXAMPLE_SAMPLE2 = v2
+EXAMPLE_SAMPLE3 = v3
+
+[cellranger_version]
+EXAMPLE_SAMPLE1 = 2.2.0
+EXAMPLE_SAMPLE2 = 2.2.0
+EXAMPLE_SAMPLE3 = 3.0.2
+
+[reference_version]
+EXAMPLE_SAMPLE1 = 2.1.0
+EXAMPLE_SAMPLE2 = 2.1.0
+EXAMPLE_SAMPLE3 = 3.0.0

--- a/scanpy_recipes/plotting/qc.py
+++ b/scanpy_recipes/plotting/qc.py
@@ -182,7 +182,7 @@ def qc_violins(adata, return_fig=False):
 
     fig.tight_layout()
     fig.text(
-        x=0.01, y=0.5, s=f"Sample: {adata.uns['sampleid']}",
+        x=0.02, y=0.5, s=f"Sample: {adata.uns['sampleid']}",
         rotation=90, va='center', ha='right', fontsize='xx-large'
     )
     fig.subplots_adjust(left=0.05)

--- a/scanpy_recipes/read_write.py
+++ b/scanpy_recipes/read_write.py
@@ -54,7 +54,7 @@ class AnalysisConfig(object):
                 assert self.placeholder_prefix not in value
         sample_ids = set(config["sample_names"].keys())
         for section in self.required_sections:
-            if section in ("names", "species", "sample_info"): continue
+            if section in ("names", "species"): continue
             assert sample_ids - set(config[section].keys()) == set()
         return config
 
@@ -137,8 +137,10 @@ def load_10x_data(sample_name: str, config: AnalysisConfig):
 
     metrics_file = os.path.join(input_dir, "metrics_summary.csv")
     adata.uns["10x_metrics"] = parse_10x_metrics(metrics_file)
-    adata.uns["10x_metrics"]["target_cells"] = config["sample_info"]["target_cells"]
-    adata.uns["10x_chemistry"] = config["sample_info"]["10x_chemistry"]
+    adata.uns["10x_metrics"]["target_cells"] = config["target_cells"].get(sample_name, None)
+    adata.uns["10x_chemistry"] = config["10x_chemistry"].get(sample_name, None)
+    adata.uns["cellranger_version"] = config["cellranger_version"].get(sample_name, None)
+    adata.uns["cellranger_reference_version"] = config["reference_version"].get(sample_name, None)
 
     adata.uns["sampleid"] = sample_name
     customer_sample_name = config["sample_names"].get(sample_name, None)
@@ -148,6 +150,7 @@ def load_10x_data(sample_name: str, config: AnalysisConfig):
     adata.uns["species"] = config["species"][genome]
 
     adata.uns["analyst"] = config["names"]["analyst_name"]
+    adata.uns["principal_investigator_name"] = config["names"]["pi_name"]
     adata.uns["customer_name"] = config["names"]["customer_name"]
     adata.uns["date_created"] = datestamp()
 

--- a/scanpy_recipes/read_write.py
+++ b/scanpy_recipes/read_write.py
@@ -150,8 +150,10 @@ def load_10x_data(sample_name: str, config: AnalysisConfig):
     adata.uns["species"] = config["species"][genome]
 
     adata.uns["analyst"] = config["names"]["analyst_name"]
-    adata.uns["principal_investigator_name"] = config["names"]["pi_name"]
     adata.uns["customer_name"] = config["names"]["customer_name"]
+    adata.uns["principal_investigator_name"] = config["names"].get(
+        "pi_name", adata.uns["customer_name"]
+    )
     adata.uns["date_created"] = datestamp()
 
     adata.uns["input_file"] = os.path.abspath(h5_file)

--- a/scanpy_recipes/recipes/aggregate.py
+++ b/scanpy_recipes/recipes/aggregate.py
@@ -94,7 +94,10 @@ def aggregate(*adatas, combined_output_dir=None,
     if del_batch_uns:
         return combined
 
-    copy_keys = ["analysis_pipeline_version", "analyst", "customer_name", "date_created", "obs_titles"]
+    copy_keys = [
+        "analysis_pipeline_version", "analyst", "customer_name",
+        "principal_investigator_name", "date_created", "obs_titles"
+    ]
     for key in copy_keys:
         combined.uns[key] = adatas[0].uns[key]
     merge_keys = set(adatas[0].uns_keys()) - set(combined.uns_keys())

--- a/scanpy_recipes/report.py
+++ b/scanpy_recipes/report.py
@@ -12,6 +12,7 @@ import scanpy.api.logging as logg
 from scanpy.plotting.anndata import scatter
 
 from .utils import datestamp
+from scanpy import __version__ as sc_version
 
 
 def fig_to_bytes(fig):
@@ -145,7 +146,8 @@ class SCBLReport(object):
             adata=adata,
             css=css,
             js=js,
-            html="\n".join(pages)
+            html="\n".join(pages),
+            scanpy_version=sc_version
         )
 
         report_file = _get_output_file(adata, ext="html")

--- a/scanpy_recipes/templates/page1.html
+++ b/scanpy_recipes/templates/page1.html
@@ -28,7 +28,7 @@
         <table>
           <tr>
             <th class="title">PI</td>
-            <td>{{ adata.uns["pi_name"] if adata.uns.get("pi_name", None) else
+            <td>{{ adata.uns["principal_investigator_name"] if adata.uns.get("principal_investigator_name", None) else
               adata.uns["customer_name"] }}</td>
           </tr>
           <tr>

--- a/scanpy_recipes/templates/page3.html
+++ b/scanpy_recipes/templates/page3.html
@@ -72,8 +72,7 @@
       <th style="text-align: right" scope="col" colspan="1" rowspan="2">QC'd Cells</th>
       <th style="text-align: right" scope="col" colspan="1" rowspan="2">QC'd Genes</th>
       <th style="text-align: right" scope="col" colspan="5" rowspan="1">Cells Excluded by</th>
-      <th style="text-align: right" scope="col" colspan="1" rowspan="2">Genes Excluded by
-      cell count</th>
+      <th style="text-align: right" scope="col" colspan="1" rowspan="2">Genes Excluded by cell count</th>
     </tr>
 
     <tr>
@@ -148,24 +147,28 @@
           {{ adata.uns["qc_metrics"]["low_count_cells_removed"] }}
           ({{ adata.uns["qc_cell_filter"]["threshold_n_counts"] }})
         </td>
-        {% if "threshold_percent_mito" in adata.uns["qc_cell_filter"] %}
         <td>
           {{ adata.uns["qc_metrics"]["high_mtrna_cells_removed"] }}
+          {% if "threshold_percent_mito" in adata.uns["qc_cell_filter"] %}
           ({{ adata.uns["qc_cell_filter"]["threshold_percent_mito"] }})
+          {% else %}
+          (--)
+          {% endif %}
         </td>
-        {% endif %}
-        {% if "threshold_hemoglobin_counts" in adata.uns["qc_cell_filter"] %}
         <td>
           {{ adata.uns["qc_metrics"]["red_blood_cells_removed"] }}
+          {% if adata.uns["qc_cell_filter"]["threshold_hemoglobin_counts"] %}
           ({{ adata.uns["qc_cell_filter"]["threshold_hemoglobin_counts"] }})
+          {% else %}
+          (--)
+          {% endif %}
         </td>
-        {% endif %}
         <td>
           {{ adata.uns["qc_metrics"]["low_sequencing_saturation_cells_removed"] }}
           {% if adata.uns["qc_cell_filter"]["threshold_sequencing_saturation"] %}
-          (--)
-          {% else %}
           ({{ adata.uns["qc_cell_filter"]["threshold_sequencing_saturation"] }})
+          {% else %}
+          (--)
           {% endif %}
         </td>
         <td>

--- a/scanpy_recipes/templates/page5.html
+++ b/scanpy_recipes/templates/page5.html
@@ -69,9 +69,32 @@
 
   <div id="software-card" class="card-body collapse" aria-labelledby="software-heading">
     <ol class="list-group list-group-flush">
-      <li class="list-group-item"><code>cellranger, version 2.2.0</code> [<a href="https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger">ref</a>]</li>
-      <li class="list-group-item"><code>cellranger {{ adata.uns["genome"] }} reference, version 2.1.0</code> [<a href="https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger">ref</a>]</li>
-      <li class="list-group-item"><code>scanpy, version 1.3.4</code> [<a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1382-0">ref</a>]</li>
+      {% if adata.uns.get("is_aggregation", False) %}
+      {% for sampleid in adata.uns["sampleids"] %}
+      <li class="list-group-item">
+        <code>cellranger, version {{ adata.uns["cellranger_version"][sampleid] }}, 10X Genomics</code>
+        [<a href="https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger">ref</a>]
+      </li>
+      {% endfor %}
+      {% for sampleid in adata.uns["sampleids"] %}
+      <li class="list-group-item"><code>{{ sampleid }}: cellranger {{ adata.uns["genome"][sampleid] }} reference,
+        version {{ adata.uns["cellranger_reference_version"][sampleid] }}, 10X Genomics</code>
+        [<a href="https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger">ref</a>]
+      </li>
+      {% endfor %}
+
+      {% else %}
+      <li class="list-group-item">
+        <code>cellranger, version {{ adata.uns["cellranger_version"] }}, 10X Genomics</code>
+        [<a href="https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger">ref</a>]
+      </li>
+      <li class="list-group-item"><code>cellranger {{ adata.uns["genome"] }} reference,
+        version {{ adata.uns["cellranger_reference_version"] }}, 10X Genomics</code>
+        [<a href="https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger">ref</a>]
+      </li>
+      {% endif %}
+
+      <li class="list-group-item"><code>scanpy, version {{ scanpy_version }}</code> [<a href="https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1382-0">ref</a>]</li>
     </ol>
   </div>
 </div>


### PR DESCRIPTION
A shoddy attempt to capture cellranger metadata.  For the time being, this will be the way forward.  In the future, the bulk of the config template string will be replaced with the sample submission sheet.

- [x] Added `target_cells`, `cellranger_version`, `cellranger_reference_version`, and `10x_chemistry` sections for each sample in the configuration string.  Parsing in `read_write` should work and aggregation correctly handles these.
- [x] Added `pi_name` to `names` section in configuration string.  This gets resolved to `adata.uns["principal_investigator_name"]` and is used in report generation.  If undefined, it still falls back to the `customer_name`.
- [x] Fixed sample ID labels on qc violin plots.
- [x] Report for single and aggregated samples should handle the the QC info and software/reference versions correctly now.